### PR TITLE
Add Dockerfile and Cloud Build setup

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+node_modules
+.git
+src
+tests
+Example_Files.zip

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+# Build the static assets
+FROM node:20 AS builder
+WORKDIR /usr/src/app
+COPY package*.json ./
+RUN npm ci
+COPY . .
+RUN npm run compil
+
+# Runtime image
+FROM node:20-alpine AS runner
+WORKDIR /app
+COPY --from=builder /usr/src/app/dist ./dist
+COPY --from=builder /usr/src/app/Editor.html ./Editor.html
+COPY --from=builder /usr/src/app/index.html ./index.html
+COPY --from=builder /usr/src/app/examples ./examples
+COPY --from=builder /usr/src/app/dependencies ./dependencies
+COPY --from=builder /usr/src/app/images ./images
+RUN npm install -g serve
+EXPOSE 8080
+CMD ["serve", "-s", ".", "-l", "8080"]

--- a/README.md
+++ b/README.md
@@ -76,6 +76,21 @@ For a more complete and detailed presentation of all Mediverse Plate Editor's fu
 ## Contributing
 Please let us know if you see any bugs or encounter display issues in your browser.
 
+## Deploying to Google Cloud Run
+
+The repository now contains a `Dockerfile` and `cloudbuild.yaml` so it can be
+built and deployed directly from Google Cloud. A typical workflow is:
+
+1. In the GCP Console open **Cloud Build → Triggers** and connect your
+   GitHub repository.
+2. Create a trigger that builds the Docker image using the provided
+   `cloudbuild.yaml` whenever you push new commits.
+3. In **Cloud Run** choose **Deploy from existing container image** and select
+   the image built by Cloud Build.
+
+The container serves the static site on port `8080`, which is the default port
+for Cloud Run services.
+
 
 ## License
 [MIT](https://choosealicense.com/licenses/mit/)

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,5 @@
+steps:
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['build', '-t', 'gcr.io/$PROJECT_ID/plateeditor:$SHORT_SHA', '.']
+images:
+- 'gcr.io/$PROJECT_ID/plateeditor:$SHORT_SHA'


### PR DESCRIPTION
## Summary
- provide Dockerfile for building the JS bundle and serving it
- ignore dev files in `.dockerignore`
- add `cloudbuild.yaml` for Cloud Build triggers
- document Cloud Run deployment steps in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6842c20518d4832aa51ecd1e69c42137