### PR TITLE
Fix asset paths for subdirectory hosting

### DIFF
--- a/Editor.html
+++ b/Editor.html
@@ -3,16 +3,16 @@
 <head>
 	<meta http-equiv="content-type" content="text/html; charset=UTF-8">
         <title>Mediverse Plate Editor</title>
-	<link href="dist/ui-styles.css" rel="stylesheet" type="text/css">
-	<link href="dist/editor-styles.css" rel="stylesheet" type="text/css">
-	<link href="dist/shared-styles.css" rel="stylesheet" type="text/css">
+        <link href="./dist/ui-styles.css" rel="stylesheet" type="text/css">
+        <link href="./dist/editor-styles.css" rel="stylesheet" type="text/css">
+        <link href="./dist/shared-styles.css" rel="stylesheet" type="text/css">
 
 	<script type="text/javascript" src="dependencies/papaparse.min.js"></script> <!--// https://www.papaparse.com //-->
 	<script type="text/javascript" src="dependencies/jszip.min.js"></script> <!--// http://stuk.github.io/jszip //-->
 	
-	<script type="text/javascript" src="dist/ui.min.js"></script>
-	<script type="text/javascript" src="dist/shared.min.js"></script>
-	<script type="text/javascript" src="dist/editor.min.js"></script>
+        <script type="text/javascript" src="./dist/ui.min.js"></script>
+        <script type="text/javascript" src="./dist/shared.min.js"></script>
+        <script type="text/javascript" src="./dist/editor.min.js"></script>
 	
 	<script type="text/javascript">
 		window.onload = function() {Editor.init()}

--- a/index.html
+++ b/index.html
@@ -3,16 +3,16 @@
 <head>
 	<meta http-equiv="content-type" content="text/html; charset=UTF-8">
         <title>Mediverse Plate Editor</title>
-	<link href="dist/ui-styles.css" rel="stylesheet" type="text/css">
-	<link href="dist/editor-styles.css" rel="stylesheet" type="text/css">
-	<link href="dist/shared-styles.css" rel="stylesheet" type="text/css">
+        <link href="./dist/ui-styles.css" rel="stylesheet" type="text/css">
+        <link href="./dist/editor-styles.css" rel="stylesheet" type="text/css">
+        <link href="./dist/shared-styles.css" rel="stylesheet" type="text/css">
 
 	<script type="text/javascript" src="dependencies/papaparse.min.js"></script> <!--// https://www.papaparse.com //-->
 	<script type="text/javascript" src="dependencies/jszip.min.js"></script> <!--// http://stuk.github.io/jszip //-->
 	
-	<script type="text/javascript" src="dist/ui.min.js"></script>
-	<script type="text/javascript" src="dist/shared.min.js"></script>
-	<script type="text/javascript" src="dist/editor.min.js"></script>
+        <script type="text/javascript" src="./dist/ui.min.js"></script>
+        <script type="text/javascript" src="./dist/shared.min.js"></script>
+        <script type="text/javascript" src="./dist/editor.min.js"></script>
 	
 	<script type="text/javascript">
 		window.onload = function() {Editor.init()}


### PR DESCRIPTION
## Summary
- fix relative paths to dist assets so the editor works when served from a subdirectory

## Testing
- `npm run compil`

------
https://chatgpt.com/codex/tasks/task_e_6842f6c16938832a802efa60ca1bec04