### PR TITLE
Add Dockerfile for static serving

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM nginx:1.25-alpine
+# Remove default nginx configuration
+RUN rm /etc/nginx/conf.d/default.conf
+# Copy custom nginx config
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+# Copy static site content
+COPY . /usr/share/nginx/html
+# Expose port for Cloud Run
+EXPOSE 8080
+# Run nginx in foreground
+CMD ["nginx", "-g", "daemon off;"]

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,10 @@
+server {
+    listen 8080;
+    listen [::]:8080;
+    root /usr/share/nginx/html;
+    index index.html;
+    location / {
+        try_files $uri $uri/ =404;
+    }
+}
+


### PR DESCRIPTION
## Summary
- add Dockerfile for serving the prebuilt static site via Cloud Run
- add minimal nginx configuration

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68432046f568832aa4fc48fe5599c01c